### PR TITLE
put sudo commands in their own script.

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -10,6 +10,23 @@ case "$ID" in
        *) echo 'Sorry this will only work on Ubuntu, but I would appreciate your help adapting it'; exit 1 ;;
 esac
 
+# check to see if user is in the dialout group,
+if  groups | grep -qw dialout
+then
+    echo "user is in dialout group"
+else
+    echo "user is not in dialout group"
+    echo "did you run linux_setup_admin.sh and logout and in again?"
+fi
+
+# check to see if user is in the plugdev group,
+if  groups | grep -qw plugdev
+then
+    echo "user is in plugdev group"
+else
+    echo "user is not in plugdev group"
+    echo "did you run linux_setup_admin.sh and logout and in again?"
+fi
 
 echo "This is going to download a lot of things from the internet and run things for you"
 echo "If you are not ready for that, just exit (ctrl+c) and do it yourself following"
@@ -20,15 +37,6 @@ sleep 10
 export DOWNLOADS_PATH=$HOME/Downloads
 export INSTALL_PATH=$HOME
 export RELEASE_PATH=https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-05-20/oss-cad-suite-linux-x64-20230520.tgz
-
-
-sudo apt-get install -y build-essential curl git libhidapi-hidraw0
-sudo usermod -a -G dialout,plugdev $(whoami)
-if [ ! -f /.dockerenv ]; then
-    sudo curl -o /etc/udev/rules.d/99-openfpgaloader.rules https://raw.githubusercontent.com/trabucayre/openFPGALoader/master/99-openfpgaloader.rules
-    sudo udevadm control --reload-rules && sudo udevadm trigger # force udev to take new rule
-fi
-echo "Your system is now setup and we can install the FPGA specific software"
 
 mkdir -p "$DOWNLOADS_PATH"
 curl -L -o"$DOWNLOADS_PATH"/oss-cad-suite.tgz https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-05-20/oss-cad-suite-linux-x64-20230520.tgz

--- a/setup_linux_admin.sh
+++ b/setup_linux_admin.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+set -e
+
+. /etc/os-release
+
+case "$ID" in
+  ubuntu) echo 'This is Ubuntu Linux, I can work with that' ;;
+  debian) echo 'This is Debian Linux, I can work with that' ;;
+       *) echo 'Sorry this will only work on Ubuntu, but I would appreciate your help adapting it'; exit 1 ;;
+esac
+
+
+apt-get install -y build-essential curl git libhidapi-hidraw0
+usermod -a -G dialout,plugdev $(whoami)
+# If setting up a docker container, skip the rest.
+if [ ! -f /.dockerenv ]; then
+    # install udev rules from https://github.com/trabucayre/openFPGALoader
+    curl https://raw.githubusercontent.com/trabucayre/openFPGALoader/master/99-openfpgaloader.rules -o /etc/udev/rules.d/99-openfpgaloader.rules
+    # force udev to take new rule
+    udevadm control --reload-rules
+    udevadm trigger
+fi
+echo "Your system is now setup and we can install the FPGA specific software"
+echo "run ./linux_setup.sh (no sudo needed.)"

--- a/web/content/requirements/linux/_index.md
+++ b/web/content/requirements/linux/_index.md
@@ -15,16 +15,19 @@ And you need to be able to setup your own networks (so no work locked computers)
 
 Make sure you don't try it for the first time on the day of the class, you will be unhappy and we will be as well.
 
-### Fast installation on Ubuntu
+### Scripted installation on Debian/Ubuntu
 
-If you trust me, you can run everything with:
 ```shell
-curl -sf -L https://raw.githubusercontent.com/bjonnh/fpga_class_psone/main/setup_linux.sh -o- |bash
+wget -N  https://raw.githubusercontent.com/bjonnh/fpga_class_psone/main/setup_linux_admin.sh
+sudo ./setup_linux_admin.sh
+# You will have to logout and login to get the new group pemissions.
+wget -N  https://raw.githubusercontent.com/bjonnh/fpga_class_psone/main/setup_linux.sh
+./setup_linux_admin.sh
 ```
 
 ### Linux details (useful only if you have issues)
 {{% notice style="primary" title="Attention" icon="skull-crossbones" %}}
-You need to have **cURL**, **git** and other build tools installed. 
+You need to have **cURL**, **git** and other build tools installed.
 And you need to be a member of the dialout group to be able to access the programmer serial port.
 On ubuntu, those with:
 ```shell
@@ -37,7 +40,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger # force udev to take
 {{% /notice %}}
 
 
-Go to 
+Go to
 https://github.com/YosysHQ/oss-cad-suite-build/releases/tag/2023-05-05
 and get the one for your platform, put it in /tmp
 


### PR DESCRIPTION
Still works.

```
videoteam@gator:~$ sudo ./setup_linux_admin.sh 
[sudo] password for videoteam: 
This is Debian Linux, I can work with that
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
build-essential is already the newest version (12.9).
curl is already the newest version (7.74.0-1.3+deb11u7).
git is already the newest version (1:2.30.2-1+deb11u2).
libhidapi-hidraw0 is already the newest version (0.10.1+dfsg-1).
The following package was automatically installed and is no longer required:
  linux-image-5.10.0-20-amd64
Use 'sudo apt autoremove' to remove it.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2243  100  2243    0     0  12744      0 --:--:-- --:--:-- --:--:-- 12744
Your system is now setup and we can install the FPGA specific software
run ./linux_setup.sh (no sudo needed.)
```
```
videoteam@gator:~$ ./setup_linux.sh 
This is Debian Linux, I can work with that
user is in dialout group
user is in plugdev group
This is going to download a lot of things from the internet and run things for you
If you are not ready for that, just exit (ctrl+c) and do it yourself following
the manual instructions
I will wait 10 seconds for you to stop me
...
2 warnings, 0 errors
Info: Program finished normally.
```