### PR TITLE
remove unused RELEASE_PATH

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -36,7 +36,6 @@ sleep 10
 
 export DOWNLOADS_PATH=$HOME/Downloads
 export INSTALL_PATH=$HOME
-export RELEASE_PATH=https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-05-20/oss-cad-suite-linux-x64-20230520.tgz
 
 mkdir -p "$DOWNLOADS_PATH"
 curl -L -o"$DOWNLOADS_PATH"/oss-cad-suite.tgz https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-05-20/oss-cad-suite-linux-x64-20230520.tgz


### PR DESCRIPTION
RELEASE_PATH was set but never used.  
the URL is used in the next line, I don't see a need for it to be in a var.